### PR TITLE
Remove all type warnings

### DIFF
--- a/example/src/ofApp.cpp
+++ b/example/src/ofApp.cpp
@@ -2,13 +2,13 @@
 
 //--------------------------------------------------------------
 void ofApp::setup(){
-    
+
     // the runManually flag lets us step through each iteration of t-SNE manually,
     // letting us watch the process take place. If set to false, the whole
     // process will take place internally when you run ofxTSNE::run
 
     runManually = true;
-    
+
     // first let's construct our toy dataset.
     // we will create N samples of dimension D, which will be distributed
     // into a number of classes, where a point belonging to a particular
@@ -18,73 +18,73 @@ void ofApp::setup(){
     // so we can see TSNE's ability to retain clusters of points when
     // transforming them from high-dimensional to low-dimensional space, so
     // in this example, the classes are just for us to see this clearer.
-    
-    
+
+
     // pick initial parameters
-    
-    int N = 1500;               // number of points in our dataset
-    int D = 100;                // number of dimensions in our data
-    int numClasses = 10;        // how many classes to create
-    
-    
+
+    size_t N = 1500;               // number of points in our dataset
+    size_t D = 100;                // number of dimensions in our data
+    size_t numClasses = 10;        // how many classes to create
+
+
     // first let's make our classes
-    
+
     vector<ofColor> classColors = vector<ofColor>{ofColor::red, ofColor::green,
         ofColor::blue, ofColor::cyan, ofColor::magenta, ofColor::black,
         ofColor::yellow, ofColor::violet, ofColor::pink, ofColor::gray};
     vector<vector<float> > classCenters;
     classCenters.resize(numClasses);
-    
-    for (int i = 0; i < numClasses; i++) {
+
+    for (size_t i = 0; i < numClasses; i++) {
         // pick a random center point for this class
         vector<float> classCenter;
         classCenter.resize(D);
-        for (int j=0; j<D; j++) {
+        for (size_t j = 0; j < D; j++) {
             classCenter[j] = ofRandom(1);
         }
         classCenters[i] = classCenter;
     }
-    
-    
+
+
     // now that we have defined our classes, let's make a fake dataset with N
     // points randomly distributed into our classes. we will store them as
     // a vector of TestPoints which contain the point and class assignment.
     // we will use ofxTSNE to determine the 2-dimensional t-SNE point for each
     // TestPoint.point
-    
+
     testPoints.clear();
-    
-    for (int i = 0; i < N; i++) {
+
+    for (size_t i = 0; i < N; i++) {
         // choose a random class
-        int class_ = ofRandom(numClasses);
+        size_t class_ = static_cast<size_t>(ofRandom(numClasses));
         vector<float> point;
         point.resize(D);
-        
+
         // the TestPoint will be located with some (fairly large) random
         // deviation from the center point of its class
-        for (int j=0; j<D; j++) {
+        for (size_t j = 0; j < D; j++) {
             point[j] = classCenters[class_][j] + ofRandom(-1.5, 1.5);
         }
-        
+
         // save the point and class information in a TestPoint
         TestPoint testPoint;
         testPoint.class_ = class_;
         testPoint.color = classColors[class_];
         testPoint.point = point;
-        
+
         testPoints.push_back(testPoint);
     }
-    
-    
+
+
     // now lets run our points through ofxTSNE.  ofxTSNE takes the data
     // as a vector<vector<float> > where the inner vector<float> corresponds
     // to a single data point. So let's unpack our testPoints into this.
-    
+
     vector<vector<float> > data;
-    for (int i = 0; i < N; i++) {
+    for (size_t i = 0; i < N; i++) {
         data.push_back(testPoints[i].point);
     }
-    
+
     // ofxTSNE takes four parameters:
     //
     // dims = number of dimensions to embed our points into. we will
@@ -107,23 +107,24 @@ void ofApp::setup(){
     //   noticeable accuracy.
     // normalize = this will automatically remap all tsne points to range {0, 1}
     //   if false, you'll get the original points.
-    
+
     int dims = 2;
-    float perplexity = 40;
-    float theta = 0.2;
+    double perplexity = 40;
+    double theta = 0.2;
     bool normalize = true;
-    
+
     // finally let's run ofxTSNE! this may take a while depending on your
     // data, and it will return a set of embedded points, structured as
     // a vector<vector<float> > where the inner vector contains (dims) elements.
     // We will unpack these points and assign them back to our testPoints dataset.
 
     tsnePoints = tsne.run(data, dims, perplexity, theta, normalize, runManually);
-    
+
     // if we didn't run manually, we can collect the points immediately
     if (!runManually) {
-        for (int i=0; i<testPoints.size(); i++) {
-            testPoints[i].tsnePoint = ofPoint(tsnePoints[i][0], tsnePoints[i][1]);
+        for (size_t i = 0; i < testPoints.size(); i++) {
+            testPoints[i].tsnePoint = ofPoint(static_cast<float>(tsnePoints[i][0]),
+                                              static_cast<float>(tsnePoints[i][1]));
         }
     }
 }
@@ -134,8 +135,9 @@ void ofApp::update(){
     // go through each iteration and collect the points where they currently are
     if (runManually) {
         tsnePoints = tsne.iterate();
-        for (int i=0; i<testPoints.size(); i++) {
-            testPoints[i].tsnePoint = ofPoint(tsnePoints[i][0], tsnePoints[i][1]);
+        for (size_t i = 0; i < testPoints.size(); i++) {
+            testPoints[i].tsnePoint = ofPoint(static_cast<float>(tsnePoints[i][0]),
+                                              static_cast<float>(tsnePoints[i][1]));
         }
     }
 }
@@ -143,11 +145,11 @@ void ofApp::update(){
 //--------------------------------------------------------------
 void ofApp::draw(){
     ofBackground(255);
-    for (int i=0; i<testPoints.size(); i++) {
+    for (size_t i = 0; i < testPoints.size(); i++) {
         float x = ofGetWidth() * testPoints[i].tsnePoint.x;
         float y = ofGetHeight() * testPoints[i].tsnePoint.y;
         ofSetColor(testPoints[i].color, 100);
-        ofDrawEllipse(x, y, 8, 8);
+        ofDrawCircle(x, y, 8);
     }
 }
 
@@ -202,6 +204,6 @@ void ofApp::gotMessage(ofMessage msg){
 }
 
 //--------------------------------------------------------------
-void ofApp::dragEvent(ofDragInfo dragInfo){ 
+void ofApp::dragEvent(ofDragInfo dragInfo){
 
 }

--- a/example/src/ofApp.h
+++ b/example/src/ofApp.h
@@ -21,17 +21,17 @@ class ofApp : public ofBaseApp{
 		void windowResized(int w, int h);
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
-    
+
     struct TestPoint {
-        int class_;
+        size_t class_;
         ofColor color;
         vector<float> point;
         ofPoint tsnePoint;
     };
-    
+
     ofxTSNE tsne;
     vector<TestPoint> testPoints;
     vector<vector<double> > tsnePoints;
-    
+
     bool runManually;
 };


### PR DESCRIPTION
Also remove white space at the end of lines.

Feel free to ignore this pull request if you prefer to keep it simple for beginners (int instead of size_t, float instead of double, and avoiding static_cast). I just don't like having any warnings in the IDE :)